### PR TITLE
Add AI Integration module scaffold

### DIFF
--- a/ai_integration_module/README.rst
+++ b/ai_integration_module/README.rst
@@ -1,0 +1,8 @@
+AI Integration Module
+=====================
+
+This is a demonstration addon providing a basic framework to integrate
+external AI services such as ChatGPT and Google Gemini with Odoo.
+
+The module defines placeholder models, controllers and JavaScript
+assets which can be extended for real integrations.

--- a/ai_integration_module/__init__.py
+++ b/ai_integration_module/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/ai_integration_module/__manifest__.py
+++ b/ai_integration_module/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'AI Integration Module',
+    'version': '1.0.0',
+    'summary': 'Example integration of ChatGPT and Gemini APIs.',
+    'description': 'Stubs for integrating external AI services with Odoo.',
+    'author': 'Example',
+    'license': 'AGPL-3',
+    'depends': ['base', 'mail'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/menu.xml',
+        'views/res_users_view.xml',
+        'data/ai_integration_data.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'ai_integration_module/static/src/js/ai_integration.js',
+        ],
+    },
+    'installable': True,
+}

--- a/ai_integration_module/controllers/__init__.py
+++ b/ai_integration_module/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/ai_integration_module/controllers/main.py
+++ b/ai_integration_module/controllers/main.py
@@ -1,0 +1,6 @@
+from odoo import http
+
+class AiIntegrationController(http.Controller):
+    @http.route('/ai_integration_module/ping', auth='user')
+    def ping(self, **kw):
+        return 'pong'

--- a/ai_integration_module/data/ai_integration_data.xml
+++ b/ai_integration_module/data/ai_integration_data.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <record id="action_ai_integration_settings" model="ir.actions.act_window">
+        <field name="name">AI Users</field>
+        <field name="res_model">res.users</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/ai_integration_module/models/__init__.py
+++ b/ai_integration_module/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/ai_integration_module/models/res_users.py
+++ b/ai_integration_module/models/res_users.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    chatgpt_api_key = fields.Char(string='ChatGPT API Key')
+    gemini_api_key = fields.Char(string='Gemini API Key')

--- a/ai_integration_module/security/ir.model.access.csv
+++ b/ai_integration_module/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_res_users_ai_integration,access_res_users_ai_integration,base.model_res_users,base.group_system,1,1,0,0

--- a/ai_integration_module/static/src/js/ai_integration.js
+++ b/ai_integration_module/static/src/js/ai_integration.js
@@ -1,0 +1,5 @@
+odoo.define('ai_integration_module.example', function (require) {
+    "use strict";
+
+    console.log('AI integration JS loaded');
+});

--- a/ai_integration_module/views/menu.xml
+++ b/ai_integration_module/views/menu.xml
@@ -1,0 +1,4 @@
+<odoo>
+    <menuitem id="ai_integration_menu_root" name="AI Integration" parent="base.menu_administration" sequence="60" groups="base.group_system"/>
+    <menuitem id="ai_integration_menu_users" name="AI Users" parent="ai_integration_menu_root" action="action_ai_integration_settings" sequence="10" groups="base.group_system"/>
+</odoo>

--- a/ai_integration_module/views/res_users_view.xml
+++ b/ai_integration_module/views/res_users_view.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record id="view_users_form_ai_keys" model="ir.ui.view">
+        <field name="name">res.users.form.ai.keys</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//form/sheet/notebook" position="inside">
+                <page string="AI Keys" name="page_ai_keys" groups="base.group_system">
+                    <group>
+                        <field name="chatgpt_api_key" />
+                        <field name="gemini_api_key" />
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add skeleton module `ai_integration_module`
- include manifest, init files and placeholders
- add JS asset and README
- add access rights, menus and user fields for storing ChatGPT and Gemini API keys

## Testing
- `python3 -m py_compile ai_integration_module/*.py ai_integration_module/models/*.py ai_integration_module/controllers/*.py`