### PR TITLE
Add AI bot message posting and intent routing

### DIFF
--- a/chat_ai_bot_common/__manifest__.py
+++ b/chat_ai_bot_common/__manifest__.py
@@ -44,6 +44,7 @@
     'data': [
         'security/res_groups.xml',
         'security/ir.model.access.csv',
+        'security/bot_rules.xml',
         'views/res_users.xml',
         'views/openai_log.xml',
         'views/menu.xml',

--- a/chat_ai_bot_common/models/__init__.py
+++ b/chat_ai_bot_common/models/__init__.py
@@ -2,3 +2,4 @@ from . import res_users
 from . import openai_thread
 from . import mail_thread
 from . import openai_log
+from . import intent_router

--- a/chat_ai_bot_common/models/intent_router.py
+++ b/chat_ai_bot_common/models/intent_router.py
@@ -1,0 +1,64 @@
+import json
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class IntentRouter(models.AbstractModel):
+    """Utility to classify incoming messages and route them to a channel."""
+
+    _name = 'intent.router'
+    _description = 'Intent Router'
+
+    # ------------------------------------------------------------------
+    # Intent classification
+    # ------------------------------------------------------------------
+    def classify_intent(self, message):
+        """Return the intent label for the given message using Intent GPT."""
+        api_key = self.env['ir.config_parameter'].sudo().get_param('chat_ai_bot_common.intent_gpt_api_key')
+        model = self.env['ir.config_parameter'].sudo().get_param('chat_ai_bot_common.intent_gpt_model', default='gpt-3.5-turbo')
+        if not api_key:
+            return False
+
+        try:  # pragma: no cover - third party libraries might be missing
+            import openai
+            openai.api_key = api_key
+            response = openai.ChatCompletion.create(
+                model=model,
+                messages=[{'role': 'user', 'content': message}],
+                temperature=0,
+            )
+            return response.choices[0].message['content'].strip()
+        except Exception as exc:
+            _logger.exception("Intent classification failed: %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+    def route_message(self, visitor, message):
+        """Route the visitor to a channel based on the classified intent."""
+        intent = self.classify_intent(message)
+        mapping_json = self.env['ir.config_parameter'].sudo().get_param('chat_ai_bot_common.intent_router_map')
+        mapping = json.loads(mapping_json or '{}')
+
+        channel = False
+        if intent and intent in mapping:
+            channel = self.env.ref(mapping[intent], raise_if_not_found=False)
+
+        if not channel and 'default' in mapping:
+            channel = self.env.ref(mapping['default'], raise_if_not_found=False)
+
+        if channel:
+            channel.sudo().message_post(
+                body=message,
+                author_id=visitor.id,
+                message_type='comment',
+                subtype_xmlid='mail.mt_comment',
+            )
+            return channel.id
+
+        return False
+

--- a/chat_ai_bot_common/models/res_users.py
+++ b/chat_ai_bot_common/models/res_users.py
@@ -32,3 +32,84 @@ class ResUsers(models.Model):
         if hasattr(self, '%s_run_ai_message_post' % self.llm_type):
             return getattr(self, '%s_run_ai_message_post' % self.llm_type)(recipient, channel, author, message)
         return False
+
+    # ----------------------------------------------------------
+    # OpenAI
+    # ----------------------------------------------------------
+
+    def openai_run_ai_message_post(self, recipient, channel, author, message):
+        """Send a message to OpenAI and post the response on the channel."""
+        try:
+            import openai
+        except Exception as exc:  # pragma: no cover - library missing during tests
+            _logger.error("Unable to import openai library: %s", exc)
+            return False
+
+        api_key = recipient.openai_api_key or self.env['ir.config_parameter'].sudo().get_param('chat_ai_bot_common.openai_api_key')
+        if not api_key:
+            _logger.warning("Missing OpenAI API key for user %s", recipient.id)
+            return False
+
+        openai.api_key = api_key
+        if recipient.openai_base_url:
+            openai.base_url = recipient.openai_base_url
+
+        messages = []
+        if recipient.chat_system_message:
+            messages.append({'role': 'system', 'content': recipient.chat_system_message})
+        messages.append({'role': 'user', 'content': message})
+
+        try:
+            response = openai.ChatCompletion.create(
+                model=recipient.openai_model or 'gpt-3.5-turbo',
+                messages=messages,
+                temperature=recipient.openai_temperature or 0.0,
+                max_tokens=recipient.openai_max_tokens or None,
+            )
+            answer = response.choices[0].message['content']
+        except Exception as exc:
+            _logger.exception("OpenAI request failed: %s", exc)
+            return False
+
+        channel.with_user(recipient).message_post(
+            body=answer,
+            message_type='comment',
+            subtype_xmlid='mail.mt_comment',
+        )
+        return True
+
+    # ----------------------------------------------------------
+    # Gemini
+    # ----------------------------------------------------------
+
+    def gemini_run_ai_message_post(self, recipient, channel, author, message):
+        """Send a message to Google Gemini and post the response on the channel."""
+        try:
+            import google.generativeai as genai
+        except Exception as exc:  # pragma: no cover - library missing during tests
+            _logger.error("Unable to import google.generativeai library: %s", exc)
+            return False
+
+        icp = self.env['ir.config_parameter'].sudo()
+        api_key = icp.get_param('googel_gemini_odoo_connector.gemini_api_key')
+        model_name = icp.get_param('googel_gemini_odoo_connector.gemini_model')
+        if not api_key or not model_name:
+            _logger.warning("Gemini API not configured")
+            return False
+
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel(model_name=model_name)
+
+        try:
+            res = model.generate_content(message)
+            answer = getattr(res, 'text', False) or ''
+        except Exception as exc:
+            _logger.exception("Gemini request failed: %s", exc)
+            return False
+
+        channel.with_user(recipient).message_post(
+            body=answer,
+            message_type='comment',
+            subtype_xmlid='mail.mt_comment',
+        )
+        return True

--- a/chat_ai_bot_common/security/bot_rules.xml
+++ b/chat_ai_bot_common/security/bot_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="mail_message_ai_bot_rule" model="ir.rule">
+            <field name="name">AI Bot channel messages</field>
+            <field name="model_id" ref="mail.model_mail_message"/>
+            <field name="domain_force">[('model', '=', 'discuss.channel'), ('author_id.user_id.is_ai_bot', '=', True)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+    </data>
+</odoo>
+

--- a/chat_ai_bot_common/security/res_groups.xml
+++ b/chat_ai_bot_common/security/res_groups.xml
@@ -34,5 +34,11 @@
             <field name="users" eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]"/>
             <field name="comment">Allow self editing ALL OpenAI settings: All in Medium + OpenAI Token, Max Tokens. Warning! This will allow the user to see the OpenAI token associated with him.</field>
         </record>
+
+        <record model="res.groups" id="group_ai_bot">
+            <field name="name">AI Bot</field>
+            <field name="category_id" ref="module_category_openai"/>
+            <field name="comment">Group for AI bot users</field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
## Summary
- integrate OpenAI and Gemini message posting in AI bot
- add IntentRouter model to classify and route visitor messages
- restrict posting on channels to AI bot users only
- register new security rule and group

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*