### PR TITLE
Implement AI livechat integration

### DIFF
--- a/ai_livechat/__init__.py
+++ b/ai_livechat/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/ai_livechat/__manifest__.py
+++ b/ai_livechat/__manifest__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'AI Livechat',
+    'version': '1.0.0',
+    'summary': 'Intercept livechat messages and route to AI bots',
+    'category': 'Website',
+    'author': 'Community',
+    'license': 'AGPL-3',
+    'depends': ['im_livechat', 'mail_bot'],
+    'data': ['views/ai_livechat_assets.xml'],
+    'installable': True,
+    'application': False,
+}

--- a/ai_livechat/controllers/__init__.py
+++ b/ai_livechat/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/ai_livechat/controllers/main.py
+++ b/ai_livechat/controllers/main.py
@@ -1,0 +1,31 @@
+from odoo import http
+from odoo.http import request
+
+class AiLivechatController(http.Controller):
+    @http.route('/ai_livechat/message', type='json', auth='public', website=True)
+    def ai_livechat_message(self, message=None, **kwargs):
+        """Intercept website livechat messages and open bot chat."""
+        if not message:
+            return {}
+
+        bot_partner = request.env.ref('base.partner_root')
+        user_partner = request.env.user.partner_id
+        channel = request.env['mail.channel'].search([
+            ('channel_type', '=', 'chat'),
+            ('channel_partner_ids', '=', bot_partner.id),
+            ('channel_partner_ids', '=', user_partner.id),
+        ], limit=1)
+        if not channel:
+            channel = request.env['mail.channel'].create({
+                'channel_partner_ids': [(6, 0, [bot_partner.id, user_partner.id])],
+                'channel_type': 'chat',
+                'name': 'AI Livechat',
+            })
+
+        channel.message_post(
+            body=message,
+            author_id=user_partner.id,
+            message_type='comment',
+            subtype_xmlid='mail.mt_comment'
+        )
+        return {'channel_id': channel.id}

--- a/ai_livechat/static/src/js/ai_livechat.js
+++ b/ai_livechat/static/src/js/ai_livechat.js
@@ -1,0 +1,19 @@
+/** @odoo-module */
+import { patch } from "@web/core/utils/patch";
+import { jsonrpc } from "@web/core/network/rpc_service";
+import { LivechatButton } from "@im_livechat/components/livechat_button/livechat_button";
+
+patch(LivechatButton.prototype, "ai_livechat", {
+    async _postMessage(message, options) {
+        let result = await jsonrpc('/ai_livechat/message', {message});
+        if (result && result.channel_id) {
+            this.env.services.action.doAction({
+                type: 'ir.actions.act_window',
+                res_model: 'mail.channel',
+                res_id: result.channel_id,
+                target: 'new',
+            });
+        }
+        return await this._super(message, options);
+    },
+});

--- a/ai_livechat/views/ai_livechat_assets.xml
+++ b/ai_livechat/views/ai_livechat_assets.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <template id="assets_frontend" name="ai_livechat assets" inherit_id="website.assets_frontend">
+        <xpath expr="." position="inside">
+            <script type="module" src="/ai_livechat/static/src/js/ai_livechat.js"></script>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary
- add new `ai_livechat` module with manifest
- intercept front-end messages via `/ai_livechat/message`
- patch LivechatButton client side to open a bot chat

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*