### PR TITLE
Update AI livechat search domain & auth

### DIFF
--- a/ai_livechat/controllers/main.py
+++ b/ai_livechat/controllers/main.py
@@ -2,7 +2,7 @@ from odoo import http
 from odoo.http import request
 
 class AiLivechatController(http.Controller):
-    @http.route('/ai_livechat/message', type='json', auth='public', website=True)
+    @http.route('/ai_livechat/message', type='json', auth='user', website=True)
     def ai_livechat_message(self, message=None, **kwargs):
         """Intercept website livechat messages and open bot chat."""
         if not message:
@@ -12,8 +12,8 @@ class AiLivechatController(http.Controller):
         user_partner = request.env.user.partner_id
         channel = request.env['mail.channel'].search([
             ('channel_type', '=', 'chat'),
-            ('channel_partner_ids', '=', bot_partner.id),
-            ('channel_partner_ids', '=', user_partner.id),
+            ('channel_partner_ids', 'in', [bot_partner.id]),
+            ('channel_partner_ids', 'in', [user_partner.id]),
         ], limit=1)
         if not channel:
             channel = request.env['mail.channel'].create({


### PR DESCRIPTION
## Summary
- use user auth for the AI livechat message route
- search for chat channels that include both partners

## Testing
- `python -m py_compile ai_livechat/controllers/main.py`
