### PR TITLE
Add README for AI Livechat module

### DIFF
--- a/ai_livechat/README.rst
+++ b/ai_livechat/README.rst
@@ -1,0 +1,15 @@
+AI Livechat
+===========
+
+This module intercepts messages sent through the website livechat widget and
+stores API keys on each user for AI integrations.
+
+Basic Setup
+-----------
+
+1. Install the *Live Chat* application.
+2. Configure a Live Chat channel and add the chat widget to your website.
+3. Enable the *Discuss* application.
+4. Assign AI keys on each user form.
+
+See Odoo documentation under "Websites \u2192 Live Chat" and "Productivity \u2192 Discuss" for details on configuring livechat channels and the Discuss app.


### PR DESCRIPTION
## Summary
- document AI Livechat module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*