### PR TITLE
Fix AI key fields

### DIFF
--- a/ai_chat_integration/models/res_users.py
+++ b/ai_chat_integration/models/res_users.py
@@ -3,5 +3,5 @@ from odoo import models, fields
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
-    chatgpt_api_key = fields.Char(string='ChatGPT API Key')
-    gemini_api_key = fields.Char(string='Gemini API Key')
+    chatgpt_api_key = fields.Char(string='ChatGPT API Key', password=True)
+    gemini_api_key = fields.Char(string='Gemini API Key', password=True)

--- a/ai_chat_integration/views/res_users_view.xml
+++ b/ai_chat_integration/views/res_users_view.xml
@@ -7,8 +7,8 @@
             <xpath expr="//form/sheet/notebook" position="inside">
                 <page string="AI Keys" name="page_ai_keys" groups="base.group_system">
                     <group>
-                        <field name="chatgpt_api_key" />
-                        <field name="gemini_api_key" />
+                        <field name="chatgpt_api_key" password="True" />
+                        <field name="gemini_api_key" password="True" />
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
## Summary
- mask ChatGPT and Gemini API key fields in user model
- obfuscate API key fields in users form view

## Testing
- `python3 -m compileall -q ai_chat_integration`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*